### PR TITLE
Feature/run chain from db

### DIFF
--- a/backend/app/api/endpoints/llm.py
+++ b/backend/app/api/endpoints/llm.py
@@ -1,6 +1,7 @@
 """
 Module only for llm endpoints
 to simplify the creation of a chain relative to the user
+idk what is g4f.gui.run_gui()
 """
 from typing import Dict, Any
 

--- a/backend/app/cmd/c2_tool.py
+++ b/backend/app/cmd/c2_tool.py
@@ -119,7 +119,7 @@ async def get_cmd_list_for_payload(
     return cmd_list  # os already know
 
 
-async def c2_pivoting_agent(lport, display_id, agent_type) -> str:
+async def c2_pivoting_agent(display_id, lport, agent_type) -> str:
     """ forward agent via itself, return status """
     # check support resp = await mythic.get_all_commands_for_payloadtype(
     # mythic=mythic_instance, payload_type_name="poseidon")

--- a/backend/app/cmd/proc.py
+++ b/backend/app/cmd/proc.py
@@ -28,7 +28,7 @@ async def init_agent():
 
 async def process_approved_cmd(
     cmd: str, chain_id: int, tool_name: str, display_id: int,
-    phase_name: str, p_lport: int, p_os_type: str,
+    phase_name: str, p_lport: int = 4329, p_os_type: str = "Windows",
 ) -> Tuple[AttackStep, str]:
     """ based on PHASE_COMMANDS and c2_tool defs it route cmd and execute
         no db changes to AttackStep by default cuz it depends on tasks """
@@ -44,6 +44,7 @@ async def process_approved_cmd(
         return result, llm_a
     if type_n == "payload":
         file_name = tool_n + hashlib.md5(str(time.time()).encode('utf-8'))
+        # TODO: set port/os by C2
         result = await create_payload_d(
             payload_type=tool_n, file_name=file_name,
             lport=p_lport, os_type=p_os_type  # host from default


### PR DESCRIPTION
## Description  
> Add chain run by id, it iterates over the successful steps in time order, throws them into another generator in FastAPI `StreamingResponse` so that the user knows about the results of each step. There they are processed and routed via proc. To simplify the response, I took the AttackStep model and llm analysis.

**Related Issue:** #34 

## Type of Changes  
- [ ] Bugfix (non-breaking change)  
- [x] New feature (non-breaking change)  
- [ ] Refactoring (no functional changes)  
- [ ] Documentation update  
- [ ] Tests/CI  

## Checklist  
- [x] Code follows project style guidelines  
- [ ] Tests added/updated (if applicable)  
- [x] Documentation updated (README, comments, etc.)  
- [ ] Changes do not introduce new warnings/errors  

## Additional Notes  
> This definitely needs to be improved, but there is a minimum working solution on the local agent